### PR TITLE
Minor Improvements

### DIFF
--- a/src/admin.js
+++ b/src/admin.js
@@ -8,8 +8,8 @@ const { WTSCore } = require("./core");
 class WTS extends WTSCore {
   constructor(config = {}) {
     super({
-      FETCH: fetch,
-      BTOA: btoa,
+      FETCH: fetch.bind(window),
+      BTOA: btoa.bind(window),
       ...config
     });
   }

--- a/src/core.js
+++ b/src/core.js
@@ -26,13 +26,13 @@ class WTSCore {
    * @param {String} event - Event name.
    * @param {Object} properties - Additional attributes assigned to the event.
    */
-  async trackEvent(userId, event, properties) {
+  trackEvent(userId, event, properties) {
     // ensure properties are an object
     if (typeof properties !== "object" || properties === null) {
       properties = {};
     }
 
-    this._apiCall("event", {
+    return this._apiCall("event", {
       event: event,
       identity: userId,
       properties: properties
@@ -60,14 +60,17 @@ class WTSCore {
       const body = "wts=true&data=" + encodeURIComponent(this.btoa(JSON.stringify(payload)));
       this._debug(body);
 
-      this.client(this.config.WTS_TELEMETRY_API, {
+      const apiCallPromise = this.client(this.config.WTS_TELEMETRY_API, {
         method: "POST",
         body: body,
         headers: {
           "Content-Type": "application/x-www-form-urlencoded"
         }
       });
+
       this._debug("Api call issued");
+
+      return apiCallPromise;
     } catch (e) {
       this._debug(e);
       return false;


### PR DESCRIPTION
This PR introduces two changes.

First, it ensures the promise created in the `_apiCall` is returned to the caller, which also enables the `trackEvent` method to do the same. This way, the caller of the `trackEvent` method can decide whether they want to wait for the promise to resolve or not. This can be useful if the user wants to e.g. terminate the process only after the event has been sent, not before.

With that, we also ensure that, in the Admin version of the WTS class, the provided `fetch` and `btoa` callbacks are bound to the `window` object. Without this step, the bindings change internally (because the callbacks are called via `this.`), which causes `trackEvent` calls to fail.