### PR TITLE
fix: prevent bundlers from resolving optional posthog-js at build time

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -212,7 +212,8 @@ export class WTS extends TelemetryClient {
     }
     sessionRecordingStarted = true;
 
-    import("posthog-js")
+    const mod = "posthog-js";
+    import(/* webpackIgnore: true */ /* @vite-ignore */ mod)
       .then(({ default: posthog }) => {
         posthog.init(posthogKey, {
           api_host: cfg.apiHost,


### PR DESCRIPTION
Use an opaque variable specifier plus webpackIgnore/vite-ignore magic comments so no bundler tries to resolve posthog-js during the build. Apps that don't install posthog-js will no longer fail to compile.